### PR TITLE
Composer fixes: Update requirement and fix bundle information

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,7 @@
     }
   ],
   "require": {
-    "php": ">=7.0",
-    "pimcore/core-version": "^5.1.0 || ^6.0"
+    "pimcore/pimcore": "^5.4.0 || ^6.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/DivanteClipboardBundle.php
+++ b/src/DivanteClipboardBundle.php
@@ -9,6 +9,7 @@
 namespace Divante\ClipboardBundle;
 
 use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
+use Pimcore\Extension\Bundle\Traits\PackageVersionTrait;
 
 /**
  * Class DivanteClipboardBundle
@@ -17,6 +18,16 @@ use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
  */
 class DivanteClipboardBundle extends AbstractPimcoreBundle
 {
+    use PackageVersionTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getComposerPackageName()
+    {
+        return 'divante-ltd/pimcore5-clipboard';
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -52,13 +63,5 @@ class DivanteClipboardBundle extends AbstractPimcoreBundle
     public function getDescription()
     {
         return "Shelve objects and perform actions only on these separated objects";
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getVersion()
-    {
-        return  "0.4.0";
     }
 }


### PR DESCRIPTION
1. Added usage ComposerVersionTrait for get version based on Composer info (now module has bug - tag in Composer 0.5.0, getVersion return 0.4.0)
2. Removed PHP version from requirements. It`s requirement of Pimcore and now it`s PHP >=7.1 for  5.x and PHP >=7.2 for Pimcore 6.x
3. Replace pimcore/core-version to pimcore/pimcore. It`s deprecated and for version 6.x isn`t available.